### PR TITLE
Allow loading of SDK via Dependency Injection

### DIFF
--- a/src/Aws/Laravel/AwsServiceProvider.php
+++ b/src/Aws/Laravel/AwsServiceProvider.php
@@ -59,6 +59,8 @@ class AwsServiceProvider extends ServiceProvider
 
             return $aws;
         });
+        
+        $this->app->alias('aws', 'Aws\Common\Aws');
     }
 
     /**


### PR DESCRIPTION
I avoid the use of Facades in my application as much as possible, leveraging Laravels IoC/DI capabilities to load classes throughout my application.  This change would more easily facilitate that.
